### PR TITLE
Sandbox/marquiserosier/automatically build package and upload to py pi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,6 @@ jobs:
           name: init .pypirc
           command: |
             echo -e "[pypi]" >> ~/.pypirc
-            echo -e "username = $USERNAME" >> ~/.pypirc
-            echo -e "password = $PASSWORD" >> ~/.pypirc
       - run:
           name: create packages
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: upload to pypi
           command: |
             python3 -m pip install --user --upgrade twine
-            python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/* -u $USERNAME -p $PASSWORD
+            python3 -m twine upload dist/* -u $USERNAME -p $PASSWORD
 workflows:
   version: 2
   build_and_upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python
+    steps:
+      - checkout
+      - run: 
+          name: init .pypirc
+          command: |
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "username = $USERNAME" >> ~/.pypirc
+            echo -e "password = $PASSWORD" >> ~/.pypirc
+      - run:
+          name: create packages
+          command: |
+            python3 setup.py sdist
+            python3 setup.py bdist_wheel
+      - run:
+          name: upload to pypi
+          command: |
+            python3 -m pip install --user --upgrade twine
+            python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/* -u $USERNAME -P $PASSWORD
+workflows:
+  version: 2
+  build_and_upload:
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: upload to pypi
           command: |
             python3 -m pip install --user --upgrade twine
-            python3 -m twine upload dist/* -u $USERNAME -p $PASSWORD
+            python3 -m twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD
 workflows:
   version: 2
   build_and_upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: upload to pypi
           command: |
             python3 -m pip install --user --upgrade twine
-            python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/* -u $USERNAME -P $PASSWORD
+            python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/* -u $USERNAME -p $PASSWORD
 workflows:
   version: 2
   build_and_upload:


### PR DESCRIPTION
## Overview
This PR Solves => Automatically build pip package #80

### Demo
All that is needed is to link the repository to CircleCI, and to provide CircleCI with two environmental variables: USERNAME AND PASSWORD. That is all the configuration that is needed!

The build and upload fails because I do not have proper credentials to upload to the NLP repository on pypi. Here are some pictures verifying that everything else worked however!

<img width="1920" alt="screen shot 2019-02-28 at 5 19 11 am" src="https://user-images.githubusercontent.com/12217245/53559722-beed7e00-3b18-11e9-8b42-5abd1e4c041a.png">
<img width="1920" alt="screen shot 2019-02-28 at 5 19 28 am" src="https://user-images.githubusercontent.com/12217245/53559723-beed7e00-3b18-11e9-8c68-5b2bf122a029.png">


### Notes
Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions
1) Link this repository to CircleCI
2) Change CircleCI environment variables for PYPI_USERNAME and PYPI_PASSWORD
3) Go ahead and push some changes on some branch and upload to test!
