### PR TITLE
Removed dyNET version from requirements.txt to avoid overwriting sour…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ future>=0.16.0
 scipy>=1.0.0
 nltk>=3.2.5
 requests>=2.18.4
-dyNET>=2.0.3
+dyNET
 flask
 beautifulsoup4
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="nlpcube",
-    version="0.1.0.5",
+    version="0.1.0.6",
     author="Multiple authors",
     author_email="tiberiu44@gmail.com",
     description="Natural Language Procecssing Toolkit with support for tokenization, sentence splitting, lemmatization, tagging and parsing for more than 60 languages",


### PR DESCRIPTION
## Overview
This update removes dyNET version from requirements. This is done to avoid overwriting dyNET installation that were compiled from source (the version is set to 0).

## Testing Instructions
 * Wait for tests to complete
 * Do a PIP package installation on a machine that has dyNET compiled from sources
 * pip installation should not overwrite dyNET
