### PR TITLE
Added `.DS_Store` to Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ scripts/*.json
 scripts/*.conllu
 scripts/*.md
 
+# Mac OS .DS_Store is a file that stores custom attributes of its containing folder
+.DS_Store
+
 # Jupyter notebooks
 notebooks/.ipynb_checkpoints/*
 examples/.ipynb_checkpoints


### PR DESCRIPTION
## Overview
Added the file `.DS_Store` to Gitignore, to prevent to push this file when committing from a Apple device

## Testing Instructions
 * On Mac OS, create a fork of this project before this commit. Type `git status`, a new file, `.DS_Store` has been added