### PR TITLE
Update Dockerfile to work as a web server

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu
-
+ENV DEBIAN_FRONTEND noninteractive
 
 # Installing build dependencies
 RUN apt-get update && apt-get install -y build-essential automake make cmake g++ wget git mercurial python3-pip curl
@@ -15,17 +15,7 @@ RUN wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCT
     apt-get install -y intel-mkl-64bit-2018.2-046
 
 # Installing DyNET
-RUN mkdir dynet-base && \
-    cd dynet-base && \
-    git clone https://github.com/clab/dynet.git && \
-    hg clone https://bitbucket.org/eigen/eigen -r b2e267d && \
-    cd dynet && \
-    mkdir build && \
-    cd build && \
-    cmake .. -DEIGEN3_INCLUDE_DIR=../../eigen -DPYTHON=/usr/bin/python3 -DMKL_ROOT=/opt/intel/mkl && \
-    make -j 2 && \
-    cd python && \
-    python3 ../../setup.py build --build-dir=.. --skip-build install
+RUN pip3 install dynet
 
 # Prepare environment UTF-8
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales
@@ -43,7 +33,9 @@ RUN mkdir /work && \
 
 # Prepare notebook
 RUN pip3 install jupyter
+RUN pip3 install Flask
+RUN pip3 install bs4
 
-# Start notebook
-CMD cd /work/NLP-Cube/ && python3 -m "notebook" --allow-root --ip=0.0.0.0 --no-browser
+# Start webserver
+CMD cd /work/NLP-Cube/cube/ && python3 webserver.py --port 8080 --lang=en --lang=fr --lang=de --lang=sk
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,5 +37,5 @@ RUN pip3 install Flask
 RUN pip3 install bs4
 
 # Start webserver
-CMD cd /work/NLP-Cube/cube/ && python3 webserver.py --port 8080 --lang=en --lang=fr --lang=de --lang=sk
+CMD cd /work/NLP-Cube/cube/ && python3 webserver.py --port 8080 --lang=en --lang=fr --lang=de
 


### PR DESCRIPTION
## Overview
This PR updates the Dockerfile to fix the following issues:
* the build process gets stuck at the 'Configuring tzdata' asking for geographic area
* at the 'Cloning into dynet' phase the build throws a 404 error because the eigen repository is no longer hosted on Bitbucket
* the Flask and ps4 packages are missing

### Notes
The whole process on updating the Dockefile can be seen here - #119 
Huge thanks to @tiberiu44 for his help!

## Testing Instructions
* cd to `repo-dir/docker`
* Build the image `docker build --tag nlp-cube:1.0 .`
* Start the container `docker run --publish 8080:8080 --detach --name nlp nlp-cube:1.0`
* Open the following link in your browser - [http://localhost:8080/nlp?lang=en&text=This is a simple test](http://localhost:8080/nlp?lang=en&text=This%20is%20a%20simple%20test)
