### PR TITLE
tentative support torchtext>=0.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ regex
 torch
 tqdm
 configparser
-pytorch_lightning==1.1.7
+pytorch_lightning==1.2.10
 
 transformers==4.2.2
 sentencepiece


### PR DESCRIPTION
## Overview
`pytorch-lightning==1.1.7` is too old to support recent `torchtext`

### Notes
as mentioned in https://github.com/PyTorchLightning/pytorch-lightning/pull/6211 and #100
